### PR TITLE
Update to Resonate SDK v0.7.0 (async/await)

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,16 +1,26 @@
-from resonate import Resonate
+from __future__ import annotations
 
-resonate = Resonate.remote(group="client")
+import asyncio
+import os
 
-def main():
+from resonate.resonate import Resonate
+
+
+async def main() -> None:
+    r = Resonate(url=os.environ.get("RESONATE_URL", "http://localhost:8001"))
     try:
-        id = "sleep-workflow-1"
-        func = "sleeping_workflow"
+        promise_id = "sleep-workflow-1"
         secs = 5.0
-        handle = resonate.options(target="poll://any@worker").begin_rpc(id, func=func, wf_id=id, secs=secs)
-        result = handle.result()
+        handle = r.options(target="worker").rpc(
+            promise_id, "sleeping_workflow", wf_id=promise_id, secs=secs
+        )
+        result = await handle.result()
         print(result)
     except Exception as e:
         print(e)
+    finally:
+        await r.stop()
 
-main()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,5 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "resonate-sdk>=0.6.7",
+    "resonate-sdk>=0.7.0",
 ]

--- a/worker.py
+++ b/worker.py
@@ -1,16 +1,30 @@
-from resonate import Resonate, Context
-from threading import Event
+from __future__ import annotations
 
-resonate = Resonate.remote(group="worker")
+import asyncio
+import os
+from typing import TYPE_CHECKING
 
-@resonate.register
-def sleeping_workflow(ctx: Context, wf_id: str, secs: float):
+from resonate.resonate import Resonate
+
+if TYPE_CHECKING:
+    from resonate.context import Context
+
+
+async def sleeping_workflow(ctx: Context, wf_id: str, secs: float) -> str:
     print(f"Workflow {wf_id} starting, will sleep for {secs} seconds.")
-    yield ctx.sleep(secs)
+    await ctx.sleep(secs)
     return f"Workflow {wf_id} completed after sleeping for {secs} seconds."
 
-resonate.start()
 
-print("worker is running...")
+async def main() -> None:
+    r = Resonate(
+        url=os.environ.get("RESONATE_URL", "http://localhost:8001"),
+        group="worker",
+    )
+    r.register(sleeping_workflow)
+    print("worker is running...", flush=True)
+    await asyncio.Event().wait()
 
-Event().wait()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## What changed

Migrates `worker.py` and `client.py` from the pre-0.7 generator/sync API to the v0.7.0 async/await API.

**worker.py**
- Replaced `from resonate import Resonate, Context` with `from resonate.resonate import Resonate` + `TYPE_CHECKING` guard for `Context`
- Converted `sleeping_workflow` from a generator function (`yield ctx.sleep(secs)`) to `async def` with `await ctx.sleep(secs)`
- Replaced `@resonate.register` decorator + `Resonate.remote(group="worker")` + `resonate.start()` with `Resonate(url=..., group="worker")` + `r.register(sleeping_workflow)` inside `async def main()`
- Replaced `threading.Event().wait()` keep-alive with `await asyncio.Event().wait()`
- Preserved exact ready string: `"worker is running..."` with `flush=True`

**client.py**
- Replaced sync `begin_rpc` / `handle.result()` with `r.options(target="worker").rpc(...)` + `await handle.result()`
- Wrapped in `async def main()` / `asyncio.run(main())` with `await r.stop()` in finally

**pyproject.toml**
- Bumped `resonate-sdk` floor from `>=0.6.7` to `>=0.7.0`

## How CI tests it

CI starts a Resonate server, launches `python worker.py` (waits for `worker is running` on stdout), then runs `python client.py` and expects it to complete within 30 s.